### PR TITLE
RSDEV-1043: Applying `rda-dmp-common-standard` version `0.1.2`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>rspace-digital-commons-data-adapter</artifactId>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
 
   <repositories>
     <repository>
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>digital-commons-data-java-client</artifactId>
-      <version>0.0.3</version>
+      <version>0.0.4</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Related PRs: 
 - https://github.com/rspace-os/digital-commons-data-java-client/pull/4
 - https://github.com/rspace-os/rspace-web/pull/698