### PR TITLE
RSDEV-444: Upgrade rspace-digital-commons-data-adapter to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 1.0.0 2026-04-29
+## 1.0.0 2026-07-28
 - Spring 6 / Hibernate 6 / Jakarta namespace migration
 - Switch to rspace-parent 3.0.0
 - First major version (previous releases were 0.0.x)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## [0.0.2]
  - RSpace adapter for the Digital Commons Data integration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 2.0.0 2026-04-29
+## 1.0.0 2026-04-29
 - Spring 6 / Hibernate 6 / Jakarta namespace migration
 - Switch to rspace-parent 3.0.0
+- First major version (previous releases were 0.0.x)
 
 ## [0.0.2]
  - RSpace adapter for the Digital Commons Data integration.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>2.0.1</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>rspace-digital-commons-data-adapter</artifactId>
@@ -77,15 +77,9 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <version>${servlet.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.servlet</artifactId>
-      <version>3.0</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -94,7 +88,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-repository-spi</artifactId>
-      <version>1.0.1</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>3.0.0</version>
+    <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
   </parent>
 
   <artifactId>rspace-digital-commons-data-adapter</artifactId>
@@ -85,12 +85,12 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-repository-spi</artifactId>
-      <version>2.0.0</version>
+      <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>digital-commons-data-java-client</artifactId>
-      <version>0.0.4</version>
+      <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,12 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>rspace-repository-spi</artifactId>
-      <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>digital-commons-data-java-client</artifactId>
-      <version>rsdev-444-upgrade-to-spring-6-f66247c067-1</version>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>rspace-digital-commons-data-adapter</artifactId>
-  <version>2.0.0</version>
+  <version>1.0.0</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.github.rspace-os</groupId>
       <artifactId>digital-commons-data-java-client</artifactId>
-      <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+      <version>rsdev-444-upgrade-to-spring-6-f66247c067-1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,17 +44,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>rspace-digital-commons-data-adapter</artifactId>
-  <version>0.0.6</version>
+  <version>2.0.0</version>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <artifactId>rspace-digital-commons-data-adapter</artifactId>


### PR DESCRIPTION
Upgrade rspace-digital-commons-data-adapter to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

First major bump (history only shipped 0.0.x). Pom-only: migrates servlet API from `javax.*` to `jakarta.*`, drops the obsolete Glassfish servlet test dependency, and inherits Jackson versions from the parent BOM.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
